### PR TITLE
Minor doc fixes

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -35,7 +35,9 @@ jobs:
   publish-doc:
     needs: compile-doc
     # Only publish documentation from main branch
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
+    # TODO: find out why it fails, or remove it completely
+    if: false
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write      # to deploy to Pages

--- a/README.adoc
+++ b/README.adoc
@@ -35,21 +35,21 @@ To compile the project without launching the service:
 ./gradlew build
 ----
 
+== Documentation
+
+Project technical documentation is available link:./src/docs/asciidoc/index.adoc[here].
+
 == Contribute
 
 === CRS Operation REST API
 
 The service offers a `/crs/operation` GET and POST endpoint to query a CRS Operation source code.
 
-GET example: http://localhost:8080/crs/operation?source=CRS:84&target=EPSG:4326&format=application/javascript
+GET example: http://localhost:8080/crs/operation?source=CRS:84&target=EPSG:4326&format=text/javascript
 
 The service responsible for this operation is link:src/main/java/com/geomatys/crsservice/service/CrsOperationService.java[CRSOperationService interface]. To customize behavior, replace or modify the only implementation of this interface.
 
 === Integration tests
 
 To make tests that simulate the web service, inherit the `AbstractIntegrationTest` class.
-It provides a web client that you can use to simulate HTTP requests to the server.
-
-=== Tag project
-
-Push a tag on the main branch. Gitlab-CI will handle artifact publication for you (using tag label as version).
+It provides a web client (through `createClient()` method) that you can use to simulate HTTP requests to the server.

--- a/src/docs/asciidoc/configure_deployment.adoc
+++ b/src/docs/asciidoc/configure_deployment.adoc
@@ -14,8 +14,7 @@ helm upgrade --install --atomic --debug \
       my-release-name geomatys.public/spring-boot-web
 ----
 
-Le link:../../../environments/demo-geomatys/values.yaml[fichier de valeurs du projet] configure le déploiement sur l'environnement de démo de Geomatys.
-C'est un bon point de départ pour réaliser votre propre configuration, mais les deux configurations suivantes doivent être modifiées :
+Voici un fichier de valeurs exemple qui peut être utilisé comme point de départ pour réaliser votre propre configuration :
 
 [source,yaml]
 ----
@@ -23,13 +22,28 @@ ingress:
   enabled: true
   hosts:
     - demo.geomatys.com # <.>
+
 config:
   server:
     servlet:
       context-path: "/crs-service" # <.>
+
+resources:
+  requests: <.>
+    cpu: "0.2"
+    memory: 1024Mi
+  limits: <.>
+    cpu: "1"
+    memory: 2048Mi
+
+env:
+  JAVA_TOOL_OPTIONS: "-Xms512M -Xmx1536M" <.>
 ----
 <.> Le domaine sur lequel l'application est déployée
-<.> Le préfixe
+<.> Le préfixe d'URL pour atteindre l'application
+<.> Les ressources CPU et mémoire minimales à réserver pour le déploiement
+<.> Les ressources CPU et mémoire maximales utilisables par le service
+<.> Configure la "heap size" de la JVM en adéquation avec les ressources décrites au-dessus
 
 Avec la configuration ci-dessus, la racine de l'application est déployée sur http://demo.geomatys.com/crs-service[].
 


### PR DESCRIPTION
 - Fix  request example in README
 - Fix Helm deployment example in documentation
 - Disable documentation publication for now. It is directly available/rendered in Github anyway.
   If we want to use Github pages, we have to find out why it refuses to publish HTML files compiled by asciidoc plugin.