### PR TITLE
Feat/build docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,8 @@ name: Build and test project
 
 on:
   push:
+    tags:
+      - '*'
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
@@ -13,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required for docker push
+      packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -40,9 +46,37 @@ jobs:
           path: |
             build/test-results
             build/reports/tests
+      # NOTE: on PRs, build docker image locally to ensure docker build is not broken.
+      # On main branch, push "latest" tagged image.
+      # On tags, push a docker image using tag name
       - name: Build Docker image
+        if: github.event_name == 'pull_request'
         run: |
           ./gradlew -Pmaven_settings_location='undefined' dockerBuild
+      - name: Login to Docker registry
+        if: github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push latest Docker image
+        if: github.ref == 'refs/heads/main'
+        run: >
+          ./gradlew 
+          -Pmaven_settings_location='undefined'
+          -Pversion="latest"
+          -Pspring-boot.build-image.imageName="ghcr.io/${GITHUB_REPOSITORY@L}"
+          dockerPush
+      - name: Push tagged Docker image
+        if: startsWith(github.event.ref, 'refs/tags/')
+        run: >
+          ./gradlew 
+          -Pmaven_settings_location='undefined'
+          -Pversion="$GITHUB_REF_NAME"
+          -Pspring-boot.build-image.imageName="ghcr.io/${GITHUB_REPOSITORY@L}"
+          dockerPush
+
   dependency-submission:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,9 @@ jobs:
           path: |
             build/test-results
             build/reports/tests
-
+      - name: Build Docker image
+        run: |
+          ./gradlew -Pmaven_settings_location='undefined' dockerBuild
   dependency-submission:
     runs-on: ubuntu-latest
     permissions:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,9 @@ tasks.register<Exec>("dockerBuild") {
     val bootJarTask = tasks.withType<BootJar>().first()
     inputs.files(bootJarTask)
     val ctxDir = bootJarTask.destinationDirectory.asFile.get()
+    // NOTE: use absolute path to container file, for compatibility purpose with Github workflows
+    val containerFile = ctxDir.resolve("Containerfile")
     val imageVersion = project.version.let { if (it == "unspecified" || it.toString().endsWith(".x")) "latest" else it }
     val imageName = requireNotNull(project.properties["spring-boot.build-image.imageName"]).toString()
-    commandLine("docker", "build", "-t", "$imageName:$imageVersion", "$ctxDir")
+    commandLine("docker", "build",  "-f", "$containerFile", "-t", "$imageName:$imageVersion", "$ctxDir")
 }


### PR DESCRIPTION
Add docker build lifecycle to Github actions:

 - On PR, build a docker image locally to ensure docker build is still sane
 - On main branch, any push will update the published "latest" docker image
 - On tag, create a docker image whose tag/version is the tag name

@J-Christophe For now, the workflow is configured to push on Github docker registry, because I needed it for testing purpose. If you'd rather push docker images on Docker hub directly (docker.io), then we'll have to do two things before merging : 

1. You will have to add a personal access token in the repository (or organization) secrets as [documented here](https://github.com/docker/login-action?tab=readme-ov-file#docker-hub)
2. Once done, I will modify the docker login and push steps in the workflow, to switch from github packages to docker hub.

If pushing to github packages instead of docker.io is fine by you, then we can merge this PR as is. 