### PR TITLE
Add a simple OpenLayer demo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     implementation("com.geomatys.backend.spring.starters:geomatys-web-starter")
     implementation("com.geomatys.backend.spring.starters:geomatys-tracing-starter")
+    implementation("org.springframework.boot:spring-boot-starter-security")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/java/com/geomatys/crsservice/configuration/Security.java
+++ b/src/main/java/com/geomatys/crsservice/configuration/Security.java
@@ -1,0 +1,31 @@
+package com.geomatys.crsservice.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.web.header.writers.CrossOriginEmbedderPolicyHeaderWriter.CrossOriginEmbedderPolicy.REQUIRE_CORP;
+import static org.springframework.security.web.header.writers.CrossOriginOpenerPolicyHeaderWriter.CrossOriginOpenerPolicy.SAME_ORIGIN;
+
+@Configuration
+public class Security {
+
+    @Bean
+    public SecurityFilterChain securityDeactivated(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(
+                        authorize ->
+                                authorize.anyRequest().permitAll()
+                )
+                .csrf(csrf -> csrf.disable())
+                // Force HTTP response headers for better performance measurement in browser.
+                // For details, see https://stackoverflow.com/a/65959796/2678097
+                .headers(
+                        headers ->
+                                headers.crossOriginOpenerPolicy(coop -> coop.policy(SAME_ORIGIN))
+                                       .crossOriginEmbedderPolicy(coep -> coep.policy(REQUIRE_CORP))
+                )
+                .build();
+    }
+}

--- a/src/main/resources/static/ol-polar-sandbox/index.html
+++ b/src/main/resources/static/ol-polar-sandbox/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Custom polar projection demo</title>
+        <script src="https://cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"></script>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css">
+        <style>
+            .wrapper {
+                width: 100%;
+                height: 100%;
+                display: flex;
+                flex-direction: row;
+            }
+            .left {
+                display: block;
+                width: 30%;
+                height: 100%;
+            }
+            .right {
+                display: block;
+                width: 70%;
+                height: 100%;
+            }
+            .map {
+                width: 70%;
+                height: 100%;
+                position: fixed;
+            }
+        </style>
+    </head>
+    <body>
+    <div class="wrapper">
+        <div class="left">
+            <h1>OSM tiles polar reprojection</h1>
+            Display OpenStreetMap raster tiles on a polar stereographic map.
+            <br/>
+            OSM tiles are fetched in  Google Pseudo-mercator (<em>EPSG:3857</em>) coordinate system.
+            <br/>
+            Reprojection is handled locally by OpenLayer, using transformation code provided by this instance of PDSSP CRS service.
+            <br/>
+            Coordinate transform statistics:
+            <ul>
+                <li>Forward: <em id="forward-count">0</em></li>
+                <li>Inverse: <em id="inverse-count">0</em></li>
+            </ul>
+        </div>
+        <div class="right">
+            <div id="map" class="map"></div>
+        </div>
+    </div>
+
+    <script type="module" src="./main.js"></script>
+    </body>
+</html>

--- a/src/main/resources/static/ol-polar-sandbox/main.js
+++ b/src/main/resources/static/ol-polar-sandbox/main.js
@@ -1,0 +1,92 @@
+/**
+ * Download coordinate reference system definition.
+ *
+ * @param {*} source Coordinate Reference System code (Identifier, WKT)
+ * @param {*} longFirst force longitude first if true
+ * @returns
+ */
+async function downloadCRS(source, longFirst=false) {
+    const url = '../crs/define?source=' + source + '&longitudeFirst=' + longFirst + '&format=application/json';
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Response status: ${response.status}`);
+    }
+    const json = await response.json();
+    const projection = new ol.proj.Projection({
+        code: json.code,
+        extent: json.domainOfValidity,
+        units: json.units,
+        axisOrientation: json.axisDirection[0] == "east" ? "enu" : "neu"
+    });
+    return projection;
+}
+
+/**
+ * Download the forward and inverse transforms between coordinate reference systems.
+ *
+ * @param {*} source source coordinate reference system
+ * @param {*} target target coordinate reference system
+ */
+async function downloadOperation(source, target) {
+    const sourceLongFirst = source.getAxisOrientation().startsWith("e");
+    const targetLongFirst = target.getAxisOrientation().startsWith("e");
+    const url = '../crs/operation?source=' + source.getCode() + '&sourceLongitudeFirst=' + sourceLongFirst + '&target=' + target.getCode() + '&targetLongitudeFirst=' + targetLongFirst + '&format=text/javascript';
+    const res = await fetch(url);
+    const txt = await res.text();
+    const operation = eval('(' + txt + ')');
+    return new operation();
+}
+
+// Register the CRS and transforms we will use
+const epsg3857 = ol.proj.get("EPSG:3857"); //get CRS from openlayer
+const epsg3031 = await downloadCRS("EPSG:3031"); //get CRS from server
+ol.proj.addProjection(epsg3031);
+
+// Register operation between CRS
+const op3857to3031 = await downloadOperation(epsg3857,epsg3031);
+function measure(fn, labelTarget) {
+    let count = 0;
+    let totalTimeSpent = 0;
+
+    const targetElement = document.getElementById(labelTarget)
+
+    return function(...args) {
+        //WARNING: For performance counter precision to be in microseconds, the server have to send specific response headers.
+        //         See https://stackoverflow.com/a/65959796/2678097 for details
+        const t0 = window.performance.now()
+        let result = fn(...args)
+        const t1 = window.performance.now()
+        totalTimeSpent += (t1 - t0)
+        // count++
+        // console.log(count++);
+        if (++count % 100 === 0) {
+            targetElement.textContent = `${count}+ calls. Total time spent: ~ ${totalTimeSpent.toFixed(2)} ms`
+        }
+        return result
+    }
+}
+
+ol.proj.addCoordinateTransforms(
+    epsg3857, epsg3031,
+    measure(op3857to3031.transform, "forward-count").bind(op3857to3031),
+    measure(op3857to3031.inverseTransform, "inverse-count").bind(op3857to3031)
+);
+
+
+// Create the map
+const layers = [
+    new ol.layer.Tile({
+        source: new ol.source.OSM(),
+    })
+];
+
+const map = new ol.Map({
+    layers: layers,
+    target: 'map',
+    view: new ol.View({
+        projection: epsg3031,
+        center: [0, 0],
+        extent: epsg3031.getExtent(),
+        zoom: 0,
+    }),
+});


### PR DESCRIPTION
Embed an HTML/JS snippet to serve an OpenLayer demo.
The demo displays OSM raster tiles on a polar stereographic projection.
Transformations are done in the browser using code downloaded from the crs service instance that served the demo.